### PR TITLE
Add per-test timeouts to fix silent CI hangs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 40
 
     steps:
       - name: Check out repo with submodules
@@ -41,12 +42,16 @@ jobs:
 
       - name: Run integration tests (make test)
         run: make test
+        timeout-minutes: 10
 
       - name: Build bootable floppy (make deploy)
         run: make deploy
+        timeout-minutes: 5
 
       - name: Verify headless boot (make verify)
         run: make verify
+        timeout-minutes: 5
 
       - name: SYS e2e test (make test-sys)
         run: make test-sys
+        timeout-minutes: 10

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -109,10 +109,15 @@ echo ""
 echo "=== Section 3: kvikdos smoke tests ==="
 
 # COMMAND.COM /C EXIT — should return exit code 0
-if (cd "$SRC/CMD/COMMAND" && "$BIN/dos-run" "$SRC/CMD/COMMAND/COMMAND.COM" /C EXIT) 2>&1; then
+if (cd "$SRC/CMD/COMMAND" && timeout 30 "$BIN/dos-run" "$SRC/CMD/COMMAND/COMMAND.COM" /C EXIT) 2>&1; then
     ok "COMMAND.COM /C EXIT"
 else
-    fail "COMMAND.COM /C EXIT  (exit code $?)"
+    rc=$?
+    if [[ $rc -eq 124 ]]; then
+        fail "COMMAND.COM /C EXIT  (timed out after 30s)"
+    else
+        fail "COMMAND.COM /C EXIT  (exit code $rc)"
+    fi
 fi
 
 # ── Section 4: /? help smoke tests ──────────────────────────────────────────
@@ -127,7 +132,13 @@ check_help() {
     local tool="$2"
     local expected="$3"
     local output
-    output=$("$BIN/dos-run" "$SRC/$tool" /? 2>/dev/null) || true
+    output=$(timeout 30 "$BIN/dos-run" "$SRC/$tool" /? 2>/dev/null) || {
+        rc=$?
+        if [[ $rc -eq 124 ]]; then
+            fail "$name /?  (timed out after 30s)"
+            return
+        fi
+    }
     if echo "$output" | grep -q "$expected"; then
         ok "$name /?"
     else


### PR DESCRIPTION
- Wrap each dos-run call in run_tests.sh with `timeout 30s` so a
  hung kvikdos process fails that individual test with a clear message
  instead of blocking the whole suite
- Add timeout-minutes to slow CI steps (test, deploy, verify, test-sys)
  and a 40-minute job-level ceiling so GitHub will cancel and report
  which step timed out rather than letting the job run until the
  6-hour default

https://claude.ai/code/session_01CsqNxiNdZNHHp2c2kXsFdx