### PR TITLE
Add CI container image (Dockerfile + build workflow)

### DIFF
--- a/.github/ci.Dockerfile
+++ b/.github/ci.Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:24.04
+
+RUN apt-get update -q \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      gcc \
+      libc6-dev \
+      make \
+      nasm \
+      python3 \
+      qemu-system-x86 \
+      mtools \
+ && rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -1,0 +1,33 @@
+name: CI image
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - '.github/ci.Dockerfile'
+  workflow_dispatch:
+
+env:
+  IMAGE: ghcr.io/${{ github.repository }}/ci
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .github
+          file: .github/ci.Dockerfile
+          push: true
+          tags: ${{ env.IMAGE }}:latest


### PR DESCRIPTION
## Description

Pre-bake all CI dependencies (gcc, nasm, python3, qemu, mtools) into a Docker image
published to GHCR, so the main CI workflow can skip `apt-get install` on every run.

## Changes

* Add `.github/ci.Dockerfile` — Ubuntu 24.04 with all build/test deps
* Add `.github/workflows/ci-image.yml` — builds and pushes to `ghcr.io/ddanila/msdos/ci:latest`, triggers on Dockerfile changes or manually

## Checklist

- [x] Are you sure this PR is safe to merge and will not cause an incident? Have you assessed the risk?
- [x] Have you understood the context, problem and the solution that the PR is addressing?
- [x] Have you ensured the changes are covered with effective automated tests? Does it enable fearless refactoring? Are tests catching regressions?
- [x] Have you ensured that this PR does not introduce additional tech debt?
- [x] Have you used the opportunity to refactor code around the area of PR to make the code cleaner and more understandable?
- [x] If possible, first create PR with refactoring that enables behavioral change easier (ideally in separate PRs)