### PR TITLE
Parallelize e2e tests and publish floppy artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
     paths-ignore:
       - '**.md'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -72,8 +75,8 @@ jobs:
         with:
           name: floppy
 
-      - name: SYS e2e test (make test-sys)
-        run: make test-sys
+      - name: SYS e2e test
+        run: bash tests/test_sys.sh
 
   e2e-builtins:
     needs: build
@@ -97,8 +100,8 @@ jobs:
         with:
           name: floppy
 
-      - name: Built-in + FIND e2e tests (make test-builtins)
-        run: make test-builtins
+      - name: Built-in + FIND e2e tests
+        run: bash tests/test_builtins.sh
 
   e2e-help:
     needs: build
@@ -122,5 +125,5 @@ jobs:
         with:
           name: floppy
 
-      - name: External CMD /? help + EXEPACK tests (make test-help-qemu)
-        run: make test-help-qemu
+      - name: External CMD /? help + EXEPACK tests
+        run: bash tests/test_help_qemu.sh


### PR DESCRIPTION
## Description

Split the single CI job into a build job + 3 parallel e2e test jobs to reduce wall-clock time. The build job uploads the floppy image as a workflow artifact (retained 14 days), which the e2e jobs download and run against concurrently.

## Changes

* Split `build-and-test` into `build` + `e2e-sys` / `e2e-builtins` / `e2e-help` jobs
* Upload `floppy.img` and `COMMAND.COM` as a workflow artifact via `actions/upload-artifact@v4`
* E2e jobs download the artifact and run their test target in parallel

## Checklist

- [x] Are you sure this PR is safe to merge and will not cause an incident? Have you assessed the risk?
- [x] Have you understood the context, problem and the solution that the PR is addressing?
- [ ] Have you ensured the changes are covered with effective automated tests? Does it enable fearless refactoring? Are tests catching regressions?
- [x] Have you ensured that this PR does not introduce additional tech debt?
- [x] Have you used the opportunity to refactor code around the area of PR to make the code cleaner and more understandable?
- [x] If possible, first create PR with refactoring that enables behavioral change easier (ideally in separate PRs)