### PR TITLE
Upgrade artifact actions to v5 to fix Node 20 deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,6 @@ on:
     paths-ignore:
       - '**.md'
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -45,7 +42,7 @@ jobs:
         timeout-minutes: 5
 
       - name: Upload floppy image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: floppy
           path: |
@@ -71,7 +68,7 @@ jobs:
         run: chmod 666 /dev/kvm
 
       - name: Download floppy image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: floppy
 
@@ -96,7 +93,7 @@ jobs:
         run: chmod 666 /dev/kvm
 
       - name: Download floppy image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: floppy
 
@@ -121,7 +118,7 @@ jobs:
         run: chmod 666 /dev/kvm
 
       - name: Download floppy image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: floppy
 


### PR DESCRIPTION
## Description

The `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env var workaround from PR #8 doesn't suppress the Node 20 deprecation warnings because `upload-artifact@v4` and `download-artifact@v4` still internally bundle Node 20. Upgrading to v5 which natively supports Node 24 is the proper fix.

## Changes

* Upgrade `actions/upload-artifact` from v4 to v5
* Upgrade `actions/download-artifact` from v5 to v5
* Remove `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env var (no longer needed)

## Checklist

- [x] Are you sure this PR is safe to merge and will not cause an incident? Have you assessed the risk?
- [x] Have you understood the context, problem and the solution that the PR is addressing?
- [x] Have you ensured that this PR does not introduce additional tech debt?
- [x] Have you used the opportunity to refactor code around the area of PR to make the code cleaner and more understandable?

🤖 Generated with [Claude Code](https://claude.com/claude-code)