### PR TITLE
Add FC /T and /5 E2E tests, completing FC option coverage

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -192,7 +192,7 @@ Built-ins from `COMTAB` in `CMD/COMMAND/TDATA.ASM`.
 - [ ] `RESTORE A: C: /L:12:00:00` — on or after time
 - [x] `RESTORE /?` — usage
 
-#### ~~FC~~ — done (basic, /B, /C, /L, /N, /W, /?). Remaining: /T (tab expansion), /5 (resync count)
+#### ~~FC~~ — done (all options: basic, /B, /C, /L, /N, /W, /T, /5, /?)
 
 #### DISKCOMP
 - [ ] `DISKCOMP A: A:` — compare floppies
@@ -212,7 +212,7 @@ Built-ins from `COMTAB` in `CMD/COMMAND/TDATA.ASM`.
 
 #### EDLIN
 - [x] `EDLIN file` — open file (list + quit tested; insert mode needs Ctrl+C pipe fix)
-- [ ] `EDLIN file /B` — binary (ignore ^Z)
+- [ ] `EDLIN file /B` — binary (ignore ^Z) — needs QEMU (kvikdos file reads don't pass ^Z content to EDLIN even in binary mode)
 - [x] `EDLIN /?` — usage
 
 #### FDISK

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -340,6 +340,41 @@ else
     fail "FC /L (expected diff output with filename header)"
 fi
 
+# -- FC /T: do not expand tabs (files with tab vs spaces differ) --
+printf "hello\tworld\r\n" > "$SRC/FCTAB1.TXT"
+printf "hello   world\r\n" > "$SRC/FCTAB2.TXT"
+output=$(run_dos CMD/FC/FC.EXE /T 'C:\FCTAB1.TXT' 'C:\FCTAB2.TXT') || true
+if echo "$output" | grep -q "FCTAB1.TXT"; then
+    ok "FC /T (tabs preserved, files differ)"
+else
+    fail "FC /T (expected diff output when tabs not expanded)"
+fi
+# Verify without /T the same files match (tab expanded to spaces)
+output=$(run_dos CMD/FC/FC.EXE 'C:\FCTAB1.TXT' 'C:\FCTAB2.TXT') || true
+if echo "$output" | grep -q "no differences"; then
+    ok "FC /T control (tabs expanded, files match)"
+else
+    fail "FC /T control (expected 'no differences' without /T)"
+fi
+rm -f "$SRC/FCTAB1.TXT" "$SRC/FCTAB2.TXT"
+
+# -- FC /5: resync requires 5 consecutive matching lines --
+# With /2 (default): FC resyncs after 2 matching lines → two separate diff blocks
+# With /5: only 2 matching lines between diffs → cannot resync → one large block
+printf "aaa\r\nDIFF1\r\nm1\r\nm2\r\nDIFF2\r\nm3\r\nm4\r\n" > "$SRC/FCSYN1.TXT"
+printf "aaa\r\nALT1\r\nm1\r\nm2\r\nALT2\r\nm3\r\nm4\r\n" > "$SRC/FCSYN2.TXT"
+output_default=$(run_dos CMD/FC/FC.EXE 'C:\FCSYN1.TXT' 'C:\FCSYN2.TXT') || true
+output_five=$(run_dos CMD/FC/FC.EXE /5 'C:\FCSYN1.TXT' 'C:\FCSYN2.TXT') || true
+# Default resync: two diff blocks → DIFF1 and DIFF2 in separate ***** sections
+blocks_default=$(echo "$output_default" | grep -c '^\*\*\*\*\*')
+blocks_five=$(echo "$output_five" | grep -c '^\*\*\*\*\*')
+if [[ "$blocks_default" -gt "$blocks_five" ]]; then
+    ok "FC /5 (higher resync count merges diff blocks)"
+else
+    fail "FC /5 (expected fewer separator blocks with /5 than default; got default=$blocks_default, /5=$blocks_five)"
+fi
+rm -f "$SRC/FCSYN1.TXT" "$SRC/FCSYN2.TXT"
+
 # -- TREE: directory listing --
 output=$(run_dos CMD/TREE/TREE.COM /A) || true
 if echo "$output" | grep -q "Directory PATH listing"; then


### PR DESCRIPTION
## Description

Complete FC test coverage by adding the last two untested options (/T and /5). FC now has all options covered.

Also documents EDLIN /B as needing QEMU — kvikdos file reads don't pass ^Z content to EDLIN even in binary mode.

## Changes

* Add `FC /T` test — creates temp files with tab vs spaces, verifies they differ with /T but match without it
* Add `FC /5` test — creates files with interleaved diffs, verifies higher resync count merges diff blocks
* Mark FC as fully covered in TODO.md
* Document EDLIN /B kvikdos limitation in TODO.md

## Checklist

- [x] Are you sure this PR is safe to merge and will not cause an incident? Have you assessed the risk?
- [x] Have you understood the context, problem and the solution that the PR is addressing?
- [x] Have you ensured the changes are covered with effective automated tests? Are tests catching regressions?
- [x] Have you ensured that this PR does not introduce additional tech debt?
- [x] Have you used the opportunity to refactor code around the area of PR to make the code cleaner and more understandable?
- [x] If possible, first create PR with refactoring that enables behavioral change easier (ideally in separate PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)