### PR TITLE
Add 10 more QEMU E2E built-in command tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@
 
 - ~~COMMAND /?~~ — added to `INIT.ASM`
 - ~~E2E functional tests (kvikdos)~~ — 167 tests in `run_tests.sh` (artifacts, checksums, /? help, functional: MEM, FIND, FC, TREE, SORT, COMP, ATTRIB, MORE, DEBUG, LABEL, EDLIN, REPLACE, XCOPY, GRAFTABL 437/850/STATUS, SUBST, JOIN, ASSIGN)
-- ~~E2E functional tests (QEMU, built-ins + FIND)~~ — 67 tests in `test_builtins.sh` (built-in commands + FIND functional: basic, /C, /N, /V, case-sensitivity, errorlevel + DIR path/wildcard, COPY concat/binary, DEL wildcard/read-only, ERASE, REN-to-existing, TYPE ^Z, MD nested, CD forms, CLS, CHKDSK)
+- ~~E2E functional tests (QEMU, built-ins + FIND)~~ — 77 tests in `test_builtins.sh` (built-in commands + FIND functional + CHKDSK + VOL drive, PROMPT clear, EXIT/COMMAND /C, COPY /A//B/concat/A+B, RENAME/MKDIR/RMDIR/CHDIR synonyms)
 - ~~CI golden checksums~~ — dropped (not worth maintenance)
 - ~~CHKDSK /?~~ — added
 - ~~EXEPACK fix verification~~ — verified via `make test-help-qemu` (EXEPACK corruption check)
@@ -86,25 +86,25 @@ Built-ins from `COMTAB` in `CMD/COMMAND/TDATA.ASM`.
 | Command | Options / forms to test |
 |---------|------------------------|
 | ~~DIR~~ | ~~no args (list CWD)~~, ~~path~~, ~~`*` wildcard~~, ~~`/W` (wide)~~, `/P` (pause/page — interactive) |
-| ~~COPY~~ | ~~src dest~~, ~~src+src2 dest (concat)~~, `/A` (ASCII), ~~`/B` (binary)~~, ~~`/V` (verify)~~ |
+| ~~COPY~~ | ~~src dest~~, ~~src+src2 dest (concat)~~, ~~`/A` (ASCII)~~, ~~`/B` (binary)~~, ~~`/V` (verify)~~, ~~`/A+/B` mixed concat~~ |
 | ~~DEL / ERASE~~ | ~~single file~~, ~~wildcard `*.*`~~, ~~read-only file (should fail)~~, ~~ERASE synonym~~ |
-| ~~REN / RENAME~~ | ~~simple rename~~, ~~rename to existing (should fail)~~ |
+| ~~REN / RENAME~~ | ~~simple rename~~, ~~rename to existing (should fail)~~, ~~RENAME synonym~~ |
 | ~~TYPE~~ | ~~text file~~, ~~binary file (^Z mid-file)~~ |
-| ~~MD / MKDIR~~ | ~~new dir~~, ~~nested path~~, ~~already-exists (should fail)~~ |
-| ~~CD / CHDIR~~ | ~~relative~~, ~~absolute~~, ~~drive-rooted~~, ~~no-arg (print CWD)~~ |
-| ~~RD / RMDIR~~ | ~~empty dir~~, ~~non-empty dir (should fail)~~ |
+| ~~MD / MKDIR~~ | ~~new dir~~, ~~nested path~~, ~~already-exists (should fail)~~, ~~MKDIR synonym~~ |
+| ~~CD / CHDIR~~ | ~~relative~~, ~~absolute~~, ~~drive-rooted~~, ~~no-arg (print CWD)~~, ~~CHDIR synonym~~ |
+| ~~RD / RMDIR~~ | ~~empty dir~~, ~~non-empty dir (should fail)~~, ~~RMDIR synonym~~ |
 | ~~SET~~ | ~~set new var~~, ~~overwrite var~~, ~~clear var (`SET VAR=`)~~, ~~no-arg (print env)~~ |
 | ~~PATH~~ | ~~set path~~, ~~clear path (`PATH ;`)~~, ~~no-arg (print current)~~ |
-| ~~PROMPT~~ | ~~set prompt string~~, clear prompt |
+| ~~PROMPT~~ | ~~set prompt string~~, ~~clear prompt (no-arg reset)~~ |
 | DATE | no-arg (show date), set date — interactive |
 | TIME | no-arg (show time), set time — interactive |
 | ~~VER~~ | ~~no args (shows version)~~ |
-| ~~VOL~~ | ~~no-arg (current drive)~~, `drive:` |
+| ~~VOL~~ | ~~no-arg (current drive)~~, ~~`drive:`~~ |
 | ~~BREAK~~ | ~~`BREAK ON`~~, ~~`BREAK OFF`~~, ~~no-arg (show state)~~ |
 | ~~VERIFY~~ | ~~`VERIFY ON`~~, ~~`VERIFY OFF`~~, ~~no-arg (show state)~~ |
 | ~~ECHO~~ | ~~`ECHO message`~~, ~~`ECHO ON`~~, ~~`ECHO OFF`~~, ~~`ECHO.` (blank line)~~ |
 | ~~CLS~~ | ~~no args~~ |
-| EXIT | exits secondary COMMAND shell |
+| ~~EXIT~~ | ~~exits secondary COMMAND shell (COMMAND /C)~~ |
 | ~~CTTY~~ | ~~redirect to device (used by test harness)~~ |
 | PAUSE | no-arg (waits for keypress) — interactive |
 | ~~REM~~ | ~~comment — no output~~ |

--- a/tests/test_builtins.sh
+++ b/tests/test_builtins.sh
@@ -350,6 +350,57 @@ printf '@ECHO CALL_SUB_OK\r\n' | mcopy -o -i "$TEST_IMG" - ::CALLSUB.BAT
     printf 'IF EXIST BINCOPY.TXT ECHO COPY_B_OK\r\n'
     printf 'DEL BINCOPY.TXT\r\n'
 
+    # ── VOL with explicit drive ────────────────────────────────────────────────
+    printf 'ECHO ---VOL-DRIVE---\r\n'
+    printf 'VOL A:\r\n'
+    printf 'ECHO VOL_DRIVE_DONE\r\n'
+
+    # ── PROMPT clear (no args resets to default) ───────────────────────────────
+    printf 'ECHO ---PROMPT-CLEAR---\r\n'
+    printf 'PROMPT $P$G\r\n'
+    printf 'PROMPT\r\n'
+    printf 'ECHO PROMPT_CLEAR_DONE\r\n'
+
+    # ── EXIT from secondary COMMAND shell ──────────────────────────────────────
+    printf 'ECHO ---EXIT---\r\n'
+    printf 'COMMAND /C ECHO EXIT_INNER_OK\r\n'
+    printf 'ECHO EXIT_RETURNED\r\n'
+
+    # ── COPY /A (ASCII mode — appends ^Z) ─────────────────────────────────────
+    printf 'ECHO ---COPY-A---\r\n'
+    printf 'COPY /A TEST.TXT ACOPY.TXT\r\n'
+    printf 'IF EXIST ACOPY.TXT ECHO COPY_A_OK\r\n'
+    printf 'DEL ACOPY.TXT\r\n'
+
+    # ── RENAME synonym ─────────────────────────────────────────────────────────
+    printf 'ECHO ---RENAME---\r\n'
+    printf 'COPY TEST.TXT RNSRC.TXT\r\n'
+    printf 'RENAME RNSRC.TXT RNDST.TXT\r\n'
+    printf 'IF EXIST RNDST.TXT ECHO RENAME_OK\r\n'
+    printf 'DEL RNDST.TXT\r\n'
+
+    # ── MKDIR / RMDIR synonyms ─────────────────────────────────────────────────
+    printf 'ECHO ---MKDIR-RMDIR---\r\n'
+    printf 'MKDIR SYNDIR\r\n'
+    printf 'IF EXIST SYNDIR\\NUL ECHO MKDIR_OK\r\n'
+    printf 'RMDIR SYNDIR\r\n'
+    printf 'IF NOT EXIST SYNDIR\\NUL ECHO RMDIR_OK\r\n'
+
+    # ── CHDIR synonym ─────────────────────────────────────────────────────────
+    printf 'ECHO ---CHDIR---\r\n'
+    printf 'MD CHDSYN\r\n'
+    printf 'CHDIR CHDSYN\r\n'
+    printf 'CHDIR\r\n'
+    printf 'CHDIR A:\\\r\n'
+    printf 'ECHO CHDIR_DONE\r\n'
+    printf 'RD CHDSYN\r\n'
+
+    # ── COPY /A+/B concat (ASCII + binary in same command) ─────────────────────
+    printf 'ECHO ---COPY-AB---\r\n'
+    printf 'COPY /A TEST.TXT + /B TEST2.TXT ABCOPY.TXT\r\n'
+    printf 'IF EXIST ABCOPY.TXT ECHO COPY_AB_OK\r\n'
+    printf 'DEL ABCOPY.TXT\r\n'
+
     printf 'ECHO ===DONE===\r\n'
 } | mcopy -o -i "$TEST_IMG" - ::AUTOEXEC.BAT
 
@@ -883,6 +934,90 @@ if grep -q "COPY_B_OK" "$SERIAL_LOG"; then
     ok "COPY /B (binary copy)"
 else
     fail "COPY /B (expected 'COPY_B_OK')"
+fi
+
+echo ""
+echo "--- VOL drive ---"
+
+if sed -n '/---VOL-DRIVE---/,/VOL_DRIVE_DONE/p' "$SERIAL_LOG" | grep -q "Serial Number\|Volume in drive"; then
+    ok "VOL A: (explicit drive)"
+else
+    fail "VOL A: (expected volume info for drive A:)"
+fi
+
+echo ""
+echo "--- PROMPT clear ---"
+
+if grep -q "PROMPT_CLEAR_DONE" "$SERIAL_LOG"; then
+    ok "PROMPT clear (no-arg reset, batch continues)"
+else
+    fail "PROMPT clear (expected 'PROMPT_CLEAR_DONE')"
+fi
+
+echo ""
+echo "--- EXIT ---"
+
+if grep -q "EXIT_INNER_OK" "$SERIAL_LOG"; then
+    ok "EXIT (secondary COMMAND /C executed)"
+else
+    fail "EXIT (expected 'EXIT_INNER_OK')"
+fi
+
+if grep -q "EXIT_RETURNED" "$SERIAL_LOG"; then
+    ok "EXIT (returned to parent after COMMAND /C)"
+else
+    fail "EXIT (expected 'EXIT_RETURNED')"
+fi
+
+echo ""
+echo "--- COPY /A ---"
+
+if grep -q "COPY_A_OK" "$SERIAL_LOG"; then
+    ok "COPY /A (ASCII mode)"
+else
+    fail "COPY /A (expected 'COPY_A_OK')"
+fi
+
+echo ""
+echo "--- RENAME synonym ---"
+
+if grep -q "RENAME_OK" "$SERIAL_LOG"; then
+    ok "RENAME (synonym for REN)"
+else
+    fail "RENAME (expected 'RENAME_OK')"
+fi
+
+echo ""
+echo "--- MKDIR/RMDIR synonyms ---"
+
+if grep -q "MKDIR_OK" "$SERIAL_LOG"; then
+    ok "MKDIR (synonym for MD)"
+else
+    fail "MKDIR (expected 'MKDIR_OK')"
+fi
+
+if grep -q "RMDIR_OK" "$SERIAL_LOG"; then
+    ok "RMDIR (synonym for RD)"
+else
+    fail "RMDIR (expected 'RMDIR_OK')"
+fi
+
+echo ""
+echo "--- CHDIR synonym ---"
+
+if sed -n '/---CHDIR---/,/CHDIR_DONE/p' "$SERIAL_LOG" | grep -q "CHDSYN"; then
+    ok "CHDIR (synonym for CD, entered dir)"
+else
+    fail "CHDIR (expected 'CHDSYN' in output)"
+fi
+
+echo ""
+echo "--- COPY /A+/B concat ---"
+
+if grep -q "COPY_AB_OK" "$SERIAL_LOG"; then
+    ok "COPY /A+/B (mixed ASCII+binary concat)"
+else
+    fail "COPY /A+/B (expected 'COPY_AB_OK')"
 fi
 
 # ── Summary ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Description

Expand QEMU E2E test coverage from 67 to 77 tests, covering remaining low-effort built-in command options and synonyms.

## Changes

* VOL A: — explicit drive argument
* PROMPT clear — no-arg reset to default
* EXIT — secondary COMMAND /C shell execution and return
* COPY /A — ASCII mode copy
* COPY /A+/B — mixed ASCII+binary concat
* RENAME, MKDIR, RMDIR, CHDIR — long-form synonyms
* Updated TODO.md checklist

## Checklist

- [x] Are you sure this PR is safe to merge and will not cause an incident? Have you assessed the risk?
- [x] Have you understood the context, problem and the solution that the PR is addressing?
- [x] Have you ensured the changes are covered with effective automated tests? Are tests catching regressions?
- [x] Have you ensured that this PR does not introduce additional tech debt?
- [x] Have you used the opportunity to refactor code around the area of PR to make the code cleaner and more understandable?
- [x] If possible, first create PR with refactoring that enables behavioral change easier (ideally in separate PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)